### PR TITLE
first stage: adding dependency add feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Any XL Release version before 4.8.x should use version 1.6.5 or lower of the plu
   * `releaseDescription`: Description of the subrelease (`string`)
   * `variables`: Comma-separated key-value pairs for the values of variables required by the subrelease, e.g. var1=value1,var2=value2 (`string`)
   * `asynch`: If [false], the task will wait for the subrelease to finish
+  * `gateTaskTitle`: Title of the gate task in this release that should wait for the subrelease to complete. Skipped if not specified (blank).
 
 + Create Template
   * `templateName`: Name of the template to create (`string`)

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -25,6 +25,7 @@
         <property name="releaseDescription" category="input" label="Release Description" required="false" size="large" description="Description of the subrelease."/>
         <property name="variables" category="input" required="false" description="Comma-separated key-value pairs for the values of variables required by the subrelease, e.g. var1=value1,var2=value2"/>
         <property name="asynch" category="input" required="false" kind="boolean" default="false" description="If [false], the task will wait for the subrelease to finish."/>
+        <property name="gateTaskTitle" category="input" required="false" kind="string"  description="Title of the gate task in this release that should wait for the subrelease to complete. Skipped if not specified (blank)."/>
 
         <property name="status" category="output" />
     </type>

--- a/src/main/resources/xlr/CreateAndStartSubRelease.py
+++ b/src/main/resources/xlr/CreateAndStartSubRelease.py
@@ -6,8 +6,14 @@
 
 import sys
 import time
+import inspect
 
 from xlr.XLReleaseClientUtil import XLReleaseClientUtil
+
+def find_planned_gate_task(tasks):
+    for task in tasks:
+        if task["status"] == "PLANNED":
+            return task
 
 def process_variables(variables, updatable_variables):
     var_map = {}
@@ -42,7 +48,7 @@ release_id = xlr_client.create_release(releaseTitle, releaseDescription, vars, r
 # Start Release
 xlr_client.start_release(release_id)
 
-# Wait for subrelease to be finished (only if asynch is true)
+# Wait for subrelease to be finished (only if asynch is false)
 while not asynch:
     status = xlr_client.get_release_status(release_id)
     if status == "COMPLETED":
@@ -52,4 +58,14 @@ while not asynch:
         print "Subrelease %s aborted in XLR" % (release_id)
         sys.exit(1)
     time.sleep(5)
+
+if gateTaskTitle:
+    tasks = taskApi.searchTasksByTitle(gateTaskTitle, None, getCurrentRelease().id)
+    task = find_planned_gate_task(tasks)
+
+    if task is None:
+        print "Couldn't find a planned gate task with title %s in current release." % gateTaskTitle
+        sys.exit(1)
+
+    xlr_client.add_dependency(release_id, task.id)    
 

--- a/src/main/resources/xlr/CreateAndStartSubRelease.py
+++ b/src/main/resources/xlr/CreateAndStartSubRelease.py
@@ -6,7 +6,6 @@
 
 import sys
 import time
-import inspect
 
 from xlr.XLReleaseClientUtil import XLReleaseClientUtil
 

--- a/src/main/resources/xlr/XLReleaseClient.py
+++ b/src/main/resources/xlr/XLReleaseClient.py
@@ -146,3 +146,21 @@ class XLReleaseClient(object):
         print "Failed to task link\n"
         print xlr_response.errorDump()
         sys.exit(1)
+
+    def add_dependency(self, dependencyReleaseId, gateTaskId):
+        # the internal api uses a rel-phase-task format instead of Applications/Rel/Phase/Task
+        # is there a cleaner way to do this??
+        # TODO move to public API once it is possible using the public API
+        internalFormatTaskId = gateTaskId.replace('Applications/', '').replace('/', '-')
+        
+        xlr_api_url = '/gates/%s/dependencies' % internalFormatTaskId
+        content = { "target": { "releaseId" : dependencyReleaseId } }
+        xlr_response = self.httpRequest.post(xlr_api_url, json.dumps(content), contentType='application/json')
+
+        if xlr_response.isSuccessful():
+            print "Dependency added to Gate task\n"
+        else:
+            print "Failed to add dependency\n"
+            print xlr_response.errorDump()
+            sys.exit(1)
+

--- a/src/main/resources/xlr/XLReleaseClient.py
+++ b/src/main/resources/xlr/XLReleaseClient.py
@@ -151,9 +151,9 @@ class XLReleaseClient(object):
         # the internal api uses a rel-phase-task format instead of Applications/Rel/Phase/Task
         # is there a cleaner way to do this??
         # TODO move to public API once it is possible using the public API
-        internalFormatTaskId = gateTaskId.replace('Applications/', '').replace('/', '-')
+        internal_format_task_id = gateTaskId.replace('Applications/', '').replace('/', '-')
         
-        xlr_api_url = '/gates/%s/dependencies' % internalFormatTaskId
+        xlr_api_url = '/gates/%s/dependencies' % internal_format_task_id
         content = { "target": { "releaseId" : dependencyReleaseId } }
         xlr_response = self.httpRequest.post(xlr_api_url, json.dumps(content), contentType='application/json')
 


### PR DESCRIPTION
"project plan"

- Create an extra property in the xlr-xlr-plugin that allow the spawned subrelease to be tied to a gate task with a certain title. I will deprecate the (brittle) async option. This plugin will use the internal API to link the gate to the subrelease
- I’ll create a pull request to add a public API resource to add and remove dependencies.
- Once (and if) this gets accepted by team Toad, I’ll update the plugin to use the updated API (although keeping it backwards compatible for a while might make sense).