### PR TITLE
Fixed template ID after folder feature in XLR was introduced.

### DIFF
--- a/src/main/resources/xlr/CreateAndStartSubRelease.py
+++ b/src/main/resources/xlr/CreateAndStartSubRelease.py
@@ -47,7 +47,7 @@ vars = process_variables(variables, updatable_variables)
 if releaseDescription is None:
     releaseDescription = ""
 
-release_id = xlr_client.create_release(releaseTitle, releaseDescription, vars, repr(template.tags).replace("'",'"'), template.id.split("/")[1])
+release_id = xlr_client.create_release(releaseTitle, releaseDescription, vars, repr(template.tags).replace("'",'"'), template.id.split("/", 1)[1])
 
 # Start Release
 xlr_client.start_release(release_id)


### PR DESCRIPTION
After the introduction of folders the plugin was broken, due a defect in template id parsing.
In the past the template ID looked like: Application/ReleaseID, now the template ID looks like: Application/folder1/../folderN/ReleaseID. So we have to split the string after the first occurrence only.
